### PR TITLE
Add new configuration options for xmpp service

### DIFF
--- a/jirecon.properties
+++ b/jirecon.properties
@@ -14,3 +14,8 @@ org.jitsi.jirecon.XMPP_PORT=5222
 # org.jitsi.jirecon.XMPP_USER=SOME_USER
 
 # org.jitsi.jirecon.XMPP_PASS=SOME_PASS
+
+org.jitsi.jirecon.XMPP_SERVICE=meet.jit.si
+
+org.jitsi.jirecon.XMPP_DEBUG=false
+

--- a/src/org/jitsi/jirecon/TaskManager.java
+++ b/src/org/jitsi/jirecon/TaskManager.java
@@ -133,10 +133,14 @@ public class TaskManager
         final int xmppPort = cfg.getInt(ConfigurationKey.XMPP_PORT_KEY, -1);
         final String xmppUser = cfg.getString(ConfigurationKey.XMPP_USER_KEY);
         final String xmppPass = cfg.getString(ConfigurationKey.XMPP_PASS_KEY);
+        final String xmppService = cfg.getString(ConfigurationKey.XMPP_SERVICE);
+        final boolean xmppDebug = cfg.getBoolean(ConfigurationKey.XMPP_DEBUG, false);
+
+        XMPPConnection.DEBUG_ENABLED = xmppDebug;
 
         try
         {
-            connect(xmppHost, xmppPort, xmppUser, xmppPass);
+            connect(xmppHost, xmppPort, xmppUser, xmppPass, xmppService);
         }
         catch (XMPPException e)
         {
@@ -260,11 +264,12 @@ public class TaskManager
      * @throws XMPPException in case of failure to connect and login.
      */
     private void connect(String xmppHost, int xmppPort,
-                         String xmppUser, String xmppPass)
+                         String xmppUser, String xmppPass,
+                         String xmppService)
         throws XMPPException
     {
         ConnectionConfiguration conf =
-            new ConnectionConfiguration(xmppHost, xmppPort);
+            new ConnectionConfiguration(xmppHost, xmppPort, xmppService);
         connection = new XMPPConnection(conf);
         connection.connect();
 

--- a/src/org/jitsi/jirecon/utils/ConfigurationKey.java
+++ b/src/org/jitsi/jirecon/utils/ConfigurationKey.java
@@ -62,6 +62,17 @@ public class ConfigurationKey
     public final static String XMPP_PASS_KEY = PREFIX + ".XMPP_PASS";
 
     /**
+     * The name of configuration property that specifies the xmpp service name
+     */
+    public final static String XMPP_SERVICE = PREFIX + ".XMPP_SERVICE";
+
+    /**
+     * The name of configuration property that specifies whether or not enter in
+     * debug mode
+     */
+    public final static String XMPP_DEBUG = PREFIX + ".XMPP_DEBUG";
+
+    /**
      * The directory name indicates where to output recording files.
      */
     public final static String SAVING_DIR_KEY = PREFIX + ".OUTPUT_DIR";


### PR DESCRIPTION
Our XMPP server uses a different 'service name', that is not the hostname.
This change allows users to configure the XMPP service name and also put XMPP in debug mode.
